### PR TITLE
Warn on files missing from asdf system definition.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@
         "fail-fast": false,
         "matrix": {
           "lisp": [
-            "sbcl-bin",
+            "sbcl-bin/2.5.10",
             "ccl-bin"
           ]
         }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@
       "env": {
         "OS": "ubuntu-latest",
         "QUICKLISP_DIST": "quicklisp",
-        "LISP": "sbcl-bin"
+        "LISP": "sbcl-bin/2.5.10"
       },
       "steps": [
         {

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@
       "env": {
         "OS": "ubuntu-latest",
         "QUICKLISP_DIST": "quicklisp",
-        "LISP": "sbcl-bin"
+        "LISP": "sbcl-bin/2.5.10"
       },
       "steps": [
         {

--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -12,6 +12,8 @@
 			      "1Gb"
                               "DYNAMIC_SPACE_SIZE"
                               "HTTP"))
+  (0.7.0 2025-12-24
+         "* A new feature was added to the imports linter. Now it will warn you if you forgot to include some files into the ASDF system definition. For now it works only for package-inferred ASDF systems.")
   (0.6.0 2025-05-11
          "* Now imports linter will ignore packages which are not correspond to ASDF system.")
   (0.5.0 2025-05-02

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,11 +1,11 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
-  :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
-  :version "2023-10-21"))
+  :initargs (:distribution "https://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
+  :version "2025-06-22"))
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
-  :initargs (:distribution "http://dist.ultralisp.org/" :%version :latest)
-  :version "20240709174002"))
+  :initargs (:distribution "https://dist.ultralisp.org/" :%version :latest)
+  :version "20251223054000"))
 ("slynk" .
  (:class qlot/source/github:source-github
   :initargs (:repos "svetlyak40wt/sly" :ref nil :branch "patches" :tag nil)

--- a/src/ci.lisp
+++ b/src/ci.lisp
@@ -16,6 +16,10 @@
   :on-pull-request t
   :cache t
   :jobs ((40ants-ci/jobs/linter:linter
+          ;; Until the issue with
+          ;; Bug in readtable iterators or concurrent access?
+          ;; will be resolved in the named-readtables.
+          :lisp "sbcl-bin/2.5.10"
           :asdf-systems ("40ants-linter"
                          "40ants-linter-docs"
                          "40ants-linter-tests"))))
@@ -25,7 +29,12 @@
   :by-cron "0 10 * * 1"
   :on-pull-request t
   :cache t
-  :jobs ((build-docs :asdf-system "40ants-linter-docs")))
+  :jobs ((build-docs
+          ;; Until the issue with
+          ;; Bug in readtable iterators or concurrent access?
+          ;; will be resolved in the named-readtables.
+          :lisp "sbcl-bin/2.5.10"
+          :asdf-system "40ants-linter-docs")))
 
 
 (defworkflow ci
@@ -34,6 +43,9 @@
   :on-pull-request t
   :cache t
   :jobs ((run-tests
-          :lisp ("sbcl-bin"
+          ;; Until the issue with
+          ;; Bug in readtable iterators or concurrent access?
+          ;; will be resolved in the named-readtables.
+          :lisp ("sbcl-bin/2.5.10"
                  "ccl-bin")
           :coverage t)))


### PR DESCRIPTION
A new feature was added to the imports linter. Now it will warn you if you forgot to include some files into the ASDF system definition. For now it works only for package-inferred ASDF systems.